### PR TITLE
Update js code according to latest Emscripten (3.1.55).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 .externalToolBuilders
 .DS_Store
 .lock-wscript
@@ -8,3 +7,4 @@ build
 .cproject
 builtins
 .internal
+*.der

--- a/example/example.script
+++ b/example/example.script
@@ -9,7 +9,7 @@ end
 
 local function download_base64_image(img)
 	local img_for_download = "data:image/png;base64," .. crypt.encode_base64(img)
-	html5.run("var link = document.createElement('a');link.download = 'screenshot.png';link.href = '" .. img_for_download .. "';link.click();link.delete();")
+	html5.run("var link = document.createElement('a');link.download = 'screenshot.png';link.href = '" .. img_for_download .. "';link.click();link.remove();")
 end
 
 local function html5_screenshot_callback(self, img)

--- a/screenshot/lib/web/lib_screenshot.js
+++ b/screenshot/lib/web/lib_screenshot.js
@@ -28,13 +28,13 @@ var LibScreenshot = {
 			// img_rgba is `Uint8ClampedArray` representing a one-dimensional array containing
 			// the data in the RGBA order, with integer values between 0 and 255 (inclusive).
 			var img_rgba = context.getImageData(dx, dy, dw, dh);
-			var img_buf = Module._malloc(img_rgba.data.length * img_rgba.data.BYTES_PER_ELEMENT);
-			Module.HEAPU8.set(img_rgba.data, img_buf);
+			var img_buf = _malloc(img_rgba.data.length * img_rgba.data.BYTES_PER_ELEMENT);
+			HEAPU8.set(img_rgba.data, img_buf);
 			document.body.removeChild(hidden_canvas);
 
 			setTimeout(function() {
 				{{{ makeDynCall("viiii", "callback") }}} (img_buf, w, h);
-				Module._free(img_buf);
+				_free(img_buf);
 			}, 0);
 
 			window.requestAnimationFrame = requestAnimationFrameSub;
@@ -43,4 +43,4 @@ var LibScreenshot = {
 	}
 }
 
-mergeInto(LibraryManager.library, LibScreenshot);
+addToLibrary(LibScreenshot);


### PR DESCRIPTION
Update js code according to latest Emscripten (3.1.55).
Fix link.delte() call (replaced with link.remove()).
Update .gitignore.

Relates to https://github.com/defold/defold/issues/6259